### PR TITLE
New feature: Language selection for multilang installers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ source utils/utils.sh
 info "Checking or building deps..."
 ./utils/build_deps.sh
 
-cmake . -B build/ -DWASM=1 -DBoost_DEBUG=1 -DUSE_LZMA=1 -DUSE_EMBOOST=1 && info "Done Cmake" || die "cmake failed"
+cmake . -B build/ -DWASM=1 -DBoost_DEBUG=1 -DUSE_LZMA=1 -DUSE_EMBOOST=1 $* && info "Done Cmake" || die "cmake failed"
 make -C build/ -j$MAKE_J && info "Done Cmake" || die "cmake failed"
 
 test_html && info "\nBUILD SUCCESS\\nTo start Innoextract go to the ./build directory and run the following command:\\npython3 -m http.server"

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -197,7 +197,6 @@ int main(int argc, char * argv[]) {
 	p.add("setup-files", -1);
 	
 	po::variables_map options;
-	
 	// Parse the command-line.
 	try {
 		po::store(po::command_line_parser(argc, argv).options(options_desc).positional(p).run(),

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -216,8 +216,8 @@ int main(int argc, char * argv[]) {
 	o.quiet = o.silent || options.count("quiet");
 	logger::quiet = o.quiet;
 #ifdef DEBUG
-	if(options.count("debug")) {
-		logger::debug = true;
+	if(!options.count("debug")) {
+		logger::debug = false;
 	}
 #endif
 	

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -24,7 +24,12 @@
 
 #include "util/console.hpp"
 
+#ifdef DEBUG
+bool logger::debug = true;
+#warning "DEBUG flag is set!"
+#else
 bool logger::debug = false;
+#endif
 bool logger::quiet = false;
 
 size_t logger::total_errors = 0;

--- a/src/wasm/extract.cpp
+++ b/src/wasm/extract.cpp
@@ -3,7 +3,6 @@
 // #include <zip.h>
 
 #include <iostream>
-#include <list>
 #include <nlohmann/json.hpp>
 
 #include "cli/goggalaxy.hpp"
@@ -275,15 +274,15 @@ std::string Context::ListFiles() {
 std::string Context::Extract(std::string list_json) {
   const std::string& output_dir = info_.header.app_name;
   auto input = json::parse(list_json);
+  auto ids = input["ids"];
   std::vector<const processed_file*> selected_files;
   selected_files.reserve(all_files_.size());
 
-  const std::string lang = input.back();
-  input.erase(input.size()-1);
+  const std::string lang = input["lang"];
 
-  std::sort(input.begin(), input.end());
-  log_info << "Unpacking " << input.size() << " files have been started.";
-  for (const auto& i : input) {
+  std::sort(ids.begin(), ids.end());
+  log_info << "Unpacking " << ids.size() << " files have been started.";
+  for (const auto& i : ids) {
     selected_files.push_back(&all_files_[i]);
   }
 

--- a/src/wasm/extract.cpp
+++ b/src/wasm/extract.cpp
@@ -3,6 +3,7 @@
 // #include <zip.h>
 
 #include <iostream>
+#include <list>
 #include <nlohmann/json.hpp>
 
 #include "cli/goggalaxy.hpp"
@@ -15,6 +16,7 @@
 #include "util/load.hpp"
 #include "util/log.hpp"
 #include "util/time.hpp"
+#include "setup/expression.hpp"
 
 
 using json = nlohmann::ordered_json;
@@ -221,6 +223,7 @@ std::string Context::ListFiles() {
     if (file.location >= info_.data_entries.size()) {
       continue;  // Ignore external files (copy commands)
     }
+
     std::string path = filenames.convert(file.destination);
     if (path.empty()) continue;
     add_dirs(dirs_, path);
@@ -275,6 +278,9 @@ std::string Context::Extract(std::string list_json) {
   std::vector<const processed_file*> selected_files;
   selected_files.reserve(all_files_.size());
 
+  const std::string lang = input.back();
+  input.erase(input.size()-1);
+
   std::sort(input.begin(), input.end());
   log_info << "Unpacking " << input.size() << " files have been started.";
   for (const auto& i : input) {
@@ -298,8 +304,10 @@ std::string Context::Extract(std::string list_json) {
   std::vector<std::vector<output_location> > files_for_location;
   files_for_location.resize(info_.data_entries.size());
 
+
   for (const processed_file* file_ptr : selected_files) {
-    files_for_location[file_ptr->entry().location].push_back(output_location(file_ptr, 0));
+    if(file_ptr->entry().languages.empty() || setup::expression_match(lang, file_ptr->entry().languages))
+      files_for_location[file_ptr->entry().location].push_back(output_location(file_ptr, 0));
     uint64_t offset = info_.data_entries[file_ptr->entry().location].uncompressed_size;
     uint32_t sort_slice = info_.data_entries[file_ptr->entry().location].chunk.first_slice;
     uint32_t sort_offset = info_.data_entries[file_ptr->entry().location].chunk.sort_offset;

--- a/src/wasm/html/css/innoextract.css
+++ b/src/wasm/html/css/innoextract.css
@@ -13,3 +13,7 @@
 .err {
     color: #dc3545;
 }
+
+#langSelect {
+    width: fit-content;
+}

--- a/src/wasm/html/index.html
+++ b/src/wasm/html/index.html
@@ -80,6 +80,7 @@
                         </div>
                         <div class="btn-group me-lg-2 w-100">
                             <button id="extractBtn" class="btn btn-warning w-100" disabled><i class="bi bi-file-earmark-zip-fill"></i> Extract and save as a ZIP! </button>
+                            <select id="langSelect" class="form-select" aria-label="Default select example" hidden></select>
                         </div>
                     </div>
                     <div id="tree"></div> 

--- a/src/wasm/html/index.html
+++ b/src/wasm/html/index.html
@@ -78,9 +78,8 @@
                         <div class="progress mb-2">
                             <div id="progress-bar" class="progress-bar" role="progressbar" style="width: 0%;">0%</div>
                         </div>
-                        <div class="btn-group me-lg-2 w-100">
-                            <button id="extractBtn" class="btn btn-warning w-100" disabled><i class="bi bi-file-earmark-zip-fill"></i> Extract and save as a ZIP! </button>
-                            <select id="langSelect" class="form-select" aria-label="Default select example" hidden></select>
+                        <div id="extract-group" class="input-group me-lg-2 w-100">
+                            <button id="extractBtn" class="btn btn-warning flex-fill" disabled><i class="bi bi-file-earmark-zip-fill"></i> Extract and save as a ZIP! </button>
                         </div>
                     </div>
                     <div id="tree"></div> 

--- a/src/wasm/html/js/innoextract.misc.js
+++ b/src/wasm/html/js/innoextract.misc.js
@@ -4,12 +4,13 @@ const removeBtn = document.getElementById("removeBtn");
 const startBtn = document.getElementById("startBtn");
 const extractBtn = document.getElementById("extractBtn");
 extractBtn.disabled = true;
+const extractGroup = document.getElementById("extract-group");
 
 //File list
 const emptyListInfo = document.getElementById("emptyListInfo");
 const fileTemplate = document.getElementById("fileTemplate");
 const fileList = document.getElementById("fileList");
-const langSelect = document.getElementById("langSelect");
+var langSelect;
 
 //Error dialog
 const errorModal = new bootstrap.Modal(document.getElementById("errorModal"));
@@ -58,6 +59,18 @@ function clearFileInfo() {
     filesNum.innerHTML = '0';
 }
 
+function addLanguageSelector() {
+    if(!document.getElementById("langSelect")){
+        extractGroup.insertAdjacentHTML('afterbegin','<select id="langSelect" class="form-select flex-fill" aria-label="Select language" hidden></select>');
+        langSelect = document.getElementById("langSelect");
+    }
+}
+
+function removeLanguageSelector() {
+    if(document.getElementById("langSelect"))
+        extractGroup.removeChild(langSelect);
+}
+
 function startInnoExtract() {
     let checked = document.querySelector('input[name="exeRadio"]:checked');
     if (checked) {
@@ -71,12 +84,15 @@ function startInnoExtract() {
                 desc.innerHTML = obj.copyrights
                 sizeInfo.innerHTML = obj.size
                 filesNum.innerHTML = obj.files_num;
-                if(obj.langs) {
+                removeLanguageSelector();
+                if(obj.langs.length > 1) {
+                    addLanguageSelector();
                     obj.langs.forEach(lang => {
                         langSelect.insertAdjacentHTML('beforeend', `<option value="${lang.name}">${lang.lang_name}</option>`);
                     });
                     langSelect.hidden = false;
                 }
+
                 Module.ccall('list_files', 'string', [], [], {async: true}).then(result =>{
                     createTree(JSON.parse(result));
                     extractBtn.disabled = false;

--- a/src/wasm/html/js/innoextract.misc.js
+++ b/src/wasm/html/js/innoextract.misc.js
@@ -9,6 +9,7 @@ extractBtn.disabled = true;
 const emptyListInfo = document.getElementById("emptyListInfo");
 const fileTemplate = document.getElementById("fileTemplate");
 const fileList = document.getElementById("fileList");
+const langSelect = document.getElementById("langSelect");
 
 //Error dialog
 const errorModal = new bootstrap.Modal(document.getElementById("errorModal"));
@@ -70,6 +71,12 @@ function startInnoExtract() {
                 desc.innerHTML = obj.copyrights
                 sizeInfo.innerHTML = obj.size
                 filesNum.innerHTML = obj.files_num;
+                if(obj.langs) {
+                    obj.langs.forEach(lang => {
+                        langSelect.insertAdjacentHTML('beforeend', `<option value="${lang.name}">${lang.lang_name}</option>`);
+                    });
+                    langSelect.hidden = false;
+                }
                 Module.ccall('list_files', 'string', [], [], {async: true}).then(result =>{
                     createTree(JSON.parse(result));
                     extractBtn.disabled = false;
@@ -84,13 +91,15 @@ function extractFiles() {
     var startDate = new Date();
     extractBtn.disabled = true;
     checked = tree.treeview('getChecked');
-    ids = []
+    info = { ids: []};
     for (const element of checked) {
         if (element.fileId !== undefined)
-            ids.push(element.fileId);
+            info.ids.push(element.fileId);
     }
-    ids.push("en");
-    Module.ccall('extract', 'string', ['string'], [JSON.stringify(ids)], {async: true}).then(result =>{
+    if(!langSelect.hidden)
+        info.lang = langSelect.value;
+
+    Module.ccall('extract', 'string', ['string'], [JSON.stringify(info)], {async: true}).then(result =>{
         extractBtn.disabled = false;
         showError(JSON.parse(result));
         var endDate   = new Date();

--- a/src/wasm/html/js/innoextract.misc.js
+++ b/src/wasm/html/js/innoextract.misc.js
@@ -89,6 +89,7 @@ function extractFiles() {
         if (element.fileId !== undefined)
             ids.push(element.fileId);
     }
+    ids.push("en");
     Module.ccall('extract', 'string', ['string'], [JSON.stringify(ids)], {async: true}).then(result =>{
         extractBtn.disabled = false;
         showError(JSON.parse(result));

--- a/src/wasm/html/js/innoextract.misc.js
+++ b/src/wasm/html/js/innoextract.misc.js
@@ -67,8 +67,10 @@ function addLanguageSelector() {
 }
 
 function removeLanguageSelector() {
-    if(document.getElementById("langSelect"))
+    if(document.getElementById("langSelect")){
         extractGroup.removeChild(langSelect);
+        langSelect = undefined;
+    }
 }
 
 function startInnoExtract() {
@@ -107,13 +109,15 @@ function extractFiles() {
     var startDate = new Date();
     extractBtn.disabled = true;
     checked = tree.treeview('getChecked');
-    info = { ids: []};
+    info = { files: []};
     for (const element of checked) {
         if (element.fileId !== undefined)
-            info.ids.push(element.fileId);
+            info.files.push(element.fileId);
     }
-    if(!langSelect.hidden)
+
+    if(langSelect){
         info.lang = langSelect.value;
+    }
 
     Module.ccall('extract', 'string', ['string'], [JSON.stringify(info)], {async: true}).then(result =>{
         extractBtn.disabled = false;

--- a/src/wasm/nonzip/nonzip.cpp
+++ b/src/wasm/nonzip/nonzip.cpp
@@ -56,7 +56,7 @@ int Nonzip::addFile(const char *name, const void *data, uint32_t dlen, uint32_t 
     }
     int i = (numfiles++);
     int nlen = strlen(name);
-    struct dostime dt = dt;
+    struct dostime dt = this->dt;
     files[i] = (struct nonzip_file *)calloc(1, sizeof(struct nonzip_file));
 
     files[i]->zf_verm = NONZIP_VERMADE_DEF;


### PR DESCRIPTION
JSON objects transferred between UI and WASM when starting the extraction process were slightly expanded to allow passing more than just a list of files, a selected language in this case.
A simple UI was added to allow language selection if the installer does support more than one language.