### PR TITLE
Fix compression errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if(WASM)
 	add_link_options(
 	-sINITIAL_MEMORY=1024MB -sSTACK_SIZE=512MB -sALLOW_MEMORY_GROWTH 
 	-sEXPORTED_RUNTIME_METHODS=ccall,cwrap -sEXPORTED_FUNCTIONS=[_main,_malloc,_free] -sINVOKE_RUN=0 -sASYNCIFY -sASYNCIFY_STACK_SIZE=65565
-	--pre-js ../src/wasm/pre.js -sNO_DISABLE_EXCEPTION_CATCHING )
+	--pre-js ../src/wasm/pre.js -sNO_DISABLE_EXCEPTION_CATCHING -sWASM_BIGINT)
 
 	add_compile_options("-fvisibility=hidden")
 	add_compile_options("-fvisibility-inlines-hidden")

--- a/src/wasm/extract.cpp
+++ b/src/wasm/extract.cpp
@@ -40,7 +40,7 @@ file_output::file_output(const fs::path& dir, const processed_file* f, bool writ
       if (file_->is_multipart()) {
         flags |= std::ios_base::in;
       }
-      if (zip_ == NULL) {
+      if(zip_ == NULL) {
         throw std::exception();
       }
     } catch (...) {

--- a/src/wasm/extract.cpp
+++ b/src/wasm/extract.cpp
@@ -40,7 +40,7 @@ file_output::file_output(const fs::path& dir, const processed_file* f, bool writ
       if (file_->is_multipart()) {
         flags |= std::ios_base::in;
       }
-      if(zip_ == NULL) {
+      if (zip_ == NULL) {
         throw std::exception();
       }
     } catch (...) {

--- a/src/wasm/extract.hpp
+++ b/src/wasm/extract.hpp
@@ -85,7 +85,7 @@ class Context {
   uint64_t total_size_;
   typedef boost::ptr_map<const processed_file*, file_output> multi_part_outputs;
   multi_part_outputs multi_outputs_;
-  ZIPstream* zip_ = NULL;
+  ZIPstream* zip_ = nullptr;
   void add_dirs(std::set<std::string>& vec, const std::string& path) const;
   uint64_t get_size() const;
   uint64_t copy_data(const stream::file_reader::pointer& source,

--- a/src/wasm/jsfile.hpp
+++ b/src/wasm/jsfile.hpp
@@ -47,7 +47,7 @@ class JSFile : public std::istream {
 extern "C" {
 int file_exist(char const* filename);
 int file_size(int file_idx);
-int read_bytes(int file_idx, void* ptr, int pos, int length);
+int read_bytes(int file_idx, void* ptr, uint64_t pos, uint64_t length);
 }
 }  // namespace wasm
 


### PR DESCRIPTION
Fix issues with LZMA and ZLIB errors, caused by 32-bit int file offset variable while reading data from input files.