### PR TITLE
Change boost from 1.74 to 1.82 to fix docker building issues

### DIFF
--- a/env
+++ b/env
@@ -1,7 +1,7 @@
 DEPDIR=$PWD/deps
 export MAKE_J=8
 
-export EMBOOSTDIR=$DEPDIR/boost_1_74_0
+export EMBOOSTDIR=$DEPDIR/boost_1_82_0
 export LZMADIR=$DEPDIR/xz-5.2.10/src/liblzma
 export JSONDIR=$DEPDIR/json-3.11.2
 #export CMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake

--- a/utils/build_deps.sh
+++ b/utils/build_deps.sh
@@ -20,7 +20,7 @@ function test_lzma() {
 }
 
 function test_boost() {
-    [ -d $DEPDIR/boost_1_74_0/stage/lib ] && [[ $(ls $DEPDIR/boost_1_74_0/stage/lib | grep bc | wc -l) -eq 7 ]]
+    [ -d $DEPDIR/boost_1_82_0/stage/lib ] && [[ $(ls $DEPDIR/boost_1_82_0/stage/lib | grep bc | wc -l) -eq 7 ]]
 }
 
 function test_json() {
@@ -56,21 +56,21 @@ function make_lzma() {
 function make_boost() {
     cd $DEPDIR
     info "Downloading boost, zlib, bzip2..."
-    wget -nv https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2 -O boost_1_74_0.tar.bz2
+    wget -nv https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2 -O boost_1_82_0.tar.bz2
     wget -nv https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -O zlib-1.2.13.tar.gz
     wget -nv https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz -O bzip2-1.0.8.tar.gz
 
     info "Unpacking..."
     tar -xaf zlib-1.2.13.tar.gz
     tar -xaf bzip2-1.0.8.tar.gz
-    tar -xaf boost_1_74_0.tar.bz2
+    tar -xaf boost_1_82_0.tar.bz2
 
     info "Configuring zlib..."
     cd $DEPDIR/zlib-1.2.13/
     emconfigure ./configure
 
     info "Patching boost..."
-    cd $DEPDIR/boost_1_74_0
+    cd $DEPDIR/boost_1_82_0
     patch -p0 < $DEPDIR/../utils/boost_p0.patch
 
     info "Building Boost, see boost.log for details..."


### PR DESCRIPTION
Fixing docker by changing boost version from 1.74 to 1.82 in ENV and build_deps.sh