### PR TITLE
Added approximate output file size - browsers will now show extraction progress

### DIFF
--- a/src/wasm/emjs.cpp
+++ b/src/wasm/emjs.cpp
@@ -81,10 +81,10 @@ EM_JS(void, ui_show_error_int, (), {
   showErrorModal();
 });
 
-EM_JS(void, open_int, (const char *name, const char *modes), {
+EM_JS(void, open_int, (const char *name, const char *modes, uint64_t output_size), {
   var fileStream;
   if(!fileStream){
-    fileStream = streamSaver.createWriteStream(UTF8ToString(name));
+    fileStream = streamSaver.createWriteStream(UTF8ToString(name), {size: output_size});
     Module.writer = fileStream.getWriter();
   }
   Module.writer.ready.then(() => {
@@ -155,8 +155,8 @@ void ui_show_error() {
   ui_show_error_int();
 }
 
-void open(const char* name, const char* modes) {
-  open_int(name, modes);
+void open(const char* name, const char* modes, uint64_t output_size) {
+  open_int(name, modes, output_size);
 }
 
 size_t write(const void* ptr, size_t size, size_t n) {

--- a/src/wasm/emjs.h
+++ b/src/wasm/emjs.h
@@ -25,7 +25,7 @@ void ui_remattr(const char* id, const char* attr);
 void ui_progbar_update(int value);
 void ui_show_error();
 
-void open(const char* name, const char* __restrict modes);
+void open(const char* name, const char* __restrict modes, uint64_t output_size);
 size_t write(const void* ptr, size_t size, size_t n);
 void close();
 

--- a/src/wasm/extract.cpp
+++ b/src/wasm/extract.cpp
@@ -406,12 +406,6 @@ std::string extractor::extract(const std::string& list_json) {
     fs::create_directory(output_dir + "/" + dir);
   }
 
-  std::string zipfile = output_dir + ".zip";
-  emjs::open(zipfile.c_str(), "wb");
-  emscripten_sleep(100);
-  output_zip_stream_ = zs_init(nullptr);
-  printf("opening zip file %s\n", zipfile.c_str());
-
   typedef std::pair<const processed_file*, uint64_t> output_location;
   std::vector<std::vector<output_location>> files_for_location;
   files_for_location.resize(installer_info_.data_entries.size());
@@ -462,6 +456,12 @@ std::string extractor::extract(const std::string& list_json) {
       total_size_ += location.uncompressed_size;
     }
   }
+
+  std::string zipfile = output_dir + ".zip";
+  emjs::open(zipfile.c_str(), "wb", total_size_);
+  emscripten_sleep(100);
+  output_zip_stream_ = zs_init(nullptr);
+  printf("opening zip file %s\n", zipfile.c_str());
 
   log_info << "Total size: " << total_size_ << " bytes";
 


### PR DESCRIPTION
Adding an approximate of output file size enables browsers to show extraction progress in their (and OS's) UI.