### PR TITLE
CMakeLists: added .version file writing with timestamp and current git version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,7 @@ if(WASM)
 	string(TIMESTAMP BUILD_DATE "%s")
     execute_process(COMMAND sh -c "git describe --dirty --always --tags" OUTPUT_VARIABLE GIT_VERSION)
 	configure_file("src/wasm/html/index.html" "${CMAKE_CURRENT_BINARY_DIR}/index.html")
+	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/.version" "${BUILD_DATE} ${GIT_VERSION}")
 
 else() #NOT WASM
 	# Prepare generated files


### PR DESCRIPTION
This will result in build/.version file being created/updated every time build finishes.