### PR TITLE
extract.cpp: Fixed handling multi-output files, added some debug

### DIFF
--- a/src/wasm/extract.hpp
+++ b/src/wasm/extract.hpp
@@ -20,8 +20,6 @@
 
 #include "wasm/fdzipstream/fdzipstream.h"
 
-#define wasm_debug(X) do { if (extractor::get().get_settings().debug_messages_enabled) log_info << X; } while(0)
-
 namespace fs = boost::filesystem;
 
 namespace wasm {

--- a/src/wasm/extract.hpp
+++ b/src/wasm/extract.hpp
@@ -20,6 +20,8 @@
 
 #include "wasm/fdzipstream/fdzipstream.h"
 
+#define wasm_debug(X) do { if (extractor::get().get_settings().debug_messages_enabled) log_info << X; } while(0)
+
 namespace fs = boost::filesystem;
 
 namespace wasm {
@@ -48,7 +50,7 @@ class file_output : private boost::noncopyable {
 public:
   file_output(const fs::path& dir, const processed_file* f, bool write, ZIPstream* zip);
 
-  bool write(char* data, size_t n);
+  bool write(char* data, size_t n, size_t size2);
   void seek(boost::uint64_t new_position);
   void close();
   const fs::path& path() const {
@@ -102,6 +104,7 @@ public:
   static extractor& get();
 
   void set_options(const std::string& options_json);
+  const ExtractionSettings& get_settings();
   bool options_differ(const std::string& options_json) const;
 
   std::string load_exe(const std::string& exe_path);
@@ -159,8 +162,8 @@ private:
                                          const std::string& output_dir);
   uint64_t seek_input_stream(stream::chunk_reader::type* chunk_source, const stream::file& file,
                              uint64_t current_offset);
-  uint64_t copy_data(const stream::file_reader::pointer& source,
-                     const std::vector<file_output*>& outputs);
+  uint64_t copy_data(const stream::file & file, const stream::file_reader::pointer& source,
+                     file_output* outputs);
 
   uint64_t get_size() const;
   void verify_close_outputs(const std::vector<file_output*>& outputs,

--- a/src/wasm/html/js/innoextract.misc.js
+++ b/src/wasm/html/js/innoextract.misc.js
@@ -56,6 +56,10 @@ $(function () {
 })
 
 function innoLog(msg, level = 'info') {
+    if (msg.length == 0) {
+        return;
+    }
+
     if (logsToFileOpt.checked) {
         logOut += level + ": " + msg + "\n";
         logLines++;


### PR DESCRIPTION
Changed logic in handling multi-output files to write them in sequence, not chunk-by-chunk.
This should fix some errors in writing output ZIPs and general file handling for some installers.