### PR TITLE
Moving from Emscripten::ccall to Embind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if(WASM)
 	add_link_options(
 	-sINITIAL_MEMORY=1024MB -sSTACK_SIZE=512MB -sALLOW_MEMORY_GROWTH 
 	-sEXPORTED_RUNTIME_METHODS=ccall,cwrap -sEXPORTED_FUNCTIONS=[_main,_malloc,_free] -sINVOKE_RUN=0 -sASYNCIFY -sASYNCIFY_STACK_SIZE=65565
-	--pre-js ../src/wasm/pre.js -sNO_DISABLE_EXCEPTION_CATCHING -sWASM_BIGINT)
+	--pre-js ../src/wasm/pre.js -sNO_DISABLE_EXCEPTION_CATCHING -sWASM_BIGINT --bind)
 	add_compile_options("-fvisibility=hidden")
 	add_compile_options("-fvisibility-inlines-hidden")
 

--- a/src/wasm/emjs.cpp
+++ b/src/wasm/emjs.cpp
@@ -1,5 +1,6 @@
 #include "emjs.h"
 #include "wasm/extract.hpp"
+#include <emscripten/bind.h>
 #include <emscripten/emscripten.h>
 #include <emscripten/val.h>
 #include <iomanip>
@@ -199,43 +200,17 @@ ssize_t emjs_write(void* buf, size_t len) {
 void abort_down(void) {
   abort_int();
 }
-
-EMSCRIPTEN_KEEPALIVE int load_file_return(char const* filename, char const* mime_type, char* buffer,
-                                          size_t buffer_size, upload_handler callback,
-                                          void* callback_data) {
-  /// Load a file - this function is called from javascript when the file upload is activated
-  callback(filename, mime_type, {buffer, buffer_size}, callback_data);
-  return 1;
-}
-
-EMSCRIPTEN_KEEPALIVE char const* load_exe(char const* filename, char const* options_json) {
-  static std::string result;
-  wasm::extractor::get().set_options(options_json);
-  result = wasm::extractor::get().load_exe(filename);
-  return result.c_str();
-}
-
-EMSCRIPTEN_KEEPALIVE char const* list_files() {
-  static std::string result;
-  result = wasm::extractor::get().list_files();
-  return result.c_str();
-}
-
-EMSCRIPTEN_KEEPALIVE char const* extract(char const* list_json) {
-  static std::string result;
-  result = wasm::extractor::get().extract(list_json);
-  return result.c_str();
-}
-
-EMSCRIPTEN_KEEPALIVE void set_abort(void) {
-  wasm::extractor::get().set_abort(true);
-}
-
-EMSCRIPTEN_KEEPALIVE int options_differ(char const * options_json) {
-  return wasm::extractor::get().options_differ(options_json);
-}
 }
 
 } // namespace
 
 } // namespace emjs
+
+EMSCRIPTEN_BINDINGS(my_module) {
+    emscripten::function("set_options", &wasm::handle::set_options);
+    emscripten::function("options_differ", &wasm::handle::options_differ);
+    emscripten::function("load_exe", &wasm::handle::load_exe);
+    emscripten::function("list_files", &wasm::handle::list_files);
+    emscripten::function("extract", &wasm::handle::extract);
+    emscripten::function("set_abort", &wasm::handle::set_abort);
+}

--- a/src/wasm/emjs.h
+++ b/src/wasm/emjs.h
@@ -31,14 +31,7 @@ void close();
 
 namespace {
 extern "C" {
-EMSCRIPTEN_KEEPALIVE int load_file_return(char const* filename, char const* mime_type, char* buffer,
-                                          size_t buffer_size, upload_handler callback,
-                                          void* callback_data);
-EMSCRIPTEN_KEEPALIVE char const* load_exe(char const* filename, char const* options_json);
-EMSCRIPTEN_KEEPALIVE char const* list_files();
-EMSCRIPTEN_KEEPALIVE char const* extract(char const* list_json);
 EMSCRIPTEN_KEEPALIVE void abort_down();
-EMSCRIPTEN_KEEPALIVE int options_differ(char const* options_json);
 }
 } // namespace
 

--- a/src/wasm/extract.cpp
+++ b/src/wasm/extract.cpp
@@ -1043,4 +1043,31 @@ void extractor::set_abort(bool state) {
   aborted = state;
 }
 
+namespace handle {
+  void set_options(const std::string& options_json) {
+    extractor::get().set_options(options_json);
+  }
+
+  bool options_differ(const std::string& options_json) {
+    return extractor::get().options_differ(options_json);
+  }
+
+  std::string load_exe(const std::string& exe_path) {
+    return extractor::get().load_exe(exe_path);
+  }
+
+  std::string list_files() {
+    return extractor::get().list_files();
+  }
+
+  std::string extract(const std::string& list_json) {
+    return extractor::get().extract(list_json);
+  }
+
+  void set_abort(bool state) {
+    return extractor::get().set_abort(state);
+  }
+
+} // namespace handle
+
 } // namespace wasm

--- a/src/wasm/extract.hpp
+++ b/src/wasm/extract.hpp
@@ -186,6 +186,16 @@ private:
   ExtractionSettings extraction_settings_{};
 };
 
+namespace handle {
+  void set_options(const std::string& options_json);
+  bool options_differ(const std::string& options_json);
+
+  std::string load_exe(const std::string& exe_path);
+  std::string list_files();
+  std::string extract(const std::string& list_json);
+  void set_abort(bool state);
+} //namespace handle
+
 } // namespace wasm
 
 #endif // INNOEXTRACT_WASM_H

--- a/src/wasm/html/js/innoextract.misc.js
+++ b/src/wasm/html/js/innoextract.misc.js
@@ -226,7 +226,8 @@ collisionResolutionOpt.addEventListener("change", updateReloadBadge, false);
 
 function updateReloadBadge() {
     var optionsJson = createOptionsJson();
-    Module.options_differ(optionsJson).then(result => {
+    new Promise((res, rej) => { return res(Module.options_differ(optionsJson));})
+    .then(result => {
         if (result != 0) {
             reloadBadge.style.display = 'unset';
         } else {
@@ -286,7 +287,8 @@ function startInnoExtract() {
         var file = global_file_list[checked.value];
         var optionsJson = createOptionsJson();
 
-        Module.load_exe(file.name).then(result => {
+        new Promise((res, rej) => { return res(Module.load_exe(file.name));})
+        .then(result => {
             var obj = JSON.parse(result)
             if (parseReturn(obj) != "err") {
                 title.innerHTML = obj.name
@@ -305,7 +307,8 @@ function startInnoExtract() {
                     });
                 }
 
-                Module.list_files().then(result => {
+                new Promise((res, rej) => { return res(Module.list_files());})
+                .then(result => {
                     createTree(JSON.parse(result));
                     extractBtn.disabled = false;
                 });
@@ -351,8 +354,8 @@ function extractFiles() {
     if (document.getElementById("langSelect")) {
         langSelect.disabled = true;
     }
-
-    Module.extract(JSON.stringify(info)).then(result => {
+    new Promise((res, rej) => { return res(Module.extract(JSON.stringify(info)));})
+    .then(result => {
         innoDebug("return: " + result)
         res = JSON.parse(result);
         parseReturn(res);
@@ -479,7 +482,8 @@ window.addEventListener('beforeunload', evt => {
 });
 
 function abortExtraction() {
-    Module.set_abort(true).then(result => {
+    new Promise((res, rej) => { return res(Module.set_abort(true));})
+    .then(result => {
         innoDebug("Abort requested");
     });
 }

--- a/src/wasm/html/js/innoextract.misc.js
+++ b/src/wasm/html/js/innoextract.misc.js
@@ -226,7 +226,7 @@ collisionResolutionOpt.addEventListener("change", updateReloadBadge, false);
 
 function updateReloadBadge() {
     var optionsJson = createOptionsJson();
-    Module.ccall('options_differ', 'int', ['string'], [optionsJson], { async: true }).then(result => {
+    Module.options_differ(optionsJson).then(result => {
         if (result != 0) {
             reloadBadge.style.display = 'unset';
         } else {
@@ -286,7 +286,7 @@ function startInnoExtract() {
         var file = global_file_list[checked.value];
         var optionsJson = createOptionsJson();
 
-        Module.ccall('load_exe', 'string', ['string', 'string'], [file.name, optionsJson], { async: true }).then(result => {
+        Module.load_exe(file.name).then(result => {
             var obj = JSON.parse(result)
             if (parseReturn(obj) != "err") {
                 title.innerHTML = obj.name
@@ -305,7 +305,7 @@ function startInnoExtract() {
                     });
                 }
 
-                Module.ccall('list_files', 'string', [], [], { async: true }).then(result => {
+                Module.list_files().then(result => {
                     createTree(JSON.parse(result));
                     extractBtn.disabled = false;
                 });
@@ -352,7 +352,7 @@ function extractFiles() {
         langSelect.disabled = true;
     }
 
-    Module.ccall('extract', 'string', ['string'], [JSON.stringify(info)], { async: true }).then(result => {
+    Module.extract(JSON.stringify(info)).then(result => {
         innoDebug("return: " + result)
         res = JSON.parse(result);
         parseReturn(res);
@@ -479,7 +479,7 @@ window.addEventListener('beforeunload', evt => {
 });
 
 function abortExtraction() {
-    Module.ccall("set_abort", "number", [], [], { async: true }).then(result => {
+    Module.set_abort(true).then(result => {
         innoDebug("Abort requested");
     });
 }


### PR DESCRIPTION
This change makes it possible to use wasm::extractor methods in a more natural way rather than as with ccall. This consists of:
- creation of handles to wasm::extractor singleton's method (C++)
- removal of functions providing API for ccalls (C++)
- creation of bindings to created singleton's handles (C++)
- refactoring of the script to utilize more natural way of using C++ functions with calling them directly (JavaScript)
- packing all of refactored binds into promises (JavaScript)